### PR TITLE
Add combo multiplier scoring

### DIFF
--- a/js/entities/Bomb.js
+++ b/js/entities/Bomb.js
@@ -35,9 +35,15 @@ export default class Bomb {
                 enemy.hp -= this.damage;
                 this.hitEnemies.add(enemy);
                 if (enemy.hp <= 0) {
-                    if (enemy.type === 'small') player.score += 10;
-                    else if (enemy.type === 'medium') player.score += 30;
-                    else if (enemy.type === 'large') player.score += 50;
+                    let baseScore = 0;
+                    if (enemy.type === 'small') baseScore = 10;
+                    else if (enemy.type === 'medium') baseScore = 30;
+                    else if (enemy.type === 'large') baseScore = 50;
+                    if (typeof player.addKillScore === 'function') {
+                        player.addKillScore(baseScore);
+                    } else {
+                        player.score += baseScore;
+                    }
                     enemies.splice(i, 1);
                 }
             }

--- a/js/entities/Melee.js
+++ b/js/entities/Melee.js
@@ -26,9 +26,15 @@ export default class Melee {
                 const angleToEnemy = Math.atan2(dy, dx);
                 const angleDiff = Math.abs(normalizeAngle(angleToEnemy - this.angle));
                 if (angleDiff <= Math.PI / 3) {
-                    if (enemy.type === 'small') player.score += 10;
-                    else if (enemy.type === 'medium') player.score += 30;
-                    else if (enemy.type === 'large') player.score += 50;
+                    let baseScore = 0;
+                    if (enemy.type === 'small') baseScore = 10;
+                    else if (enemy.type === 'medium') baseScore = 30;
+                    else if (enemy.type === 'large') baseScore = 50;
+                    if (typeof player.addKillScore === 'function') {
+                        player.addKillScore(baseScore);
+                    } else {
+                        player.score += baseScore;
+                    }
                     this.alreadyHit.add(enemy);
                     enemies.splice(i, 1);
                 }

--- a/js/entities/Player.js
+++ b/js/entities/Player.js
@@ -19,6 +19,8 @@ export default class Player {
         this.bombs = 5;
         this.lives = 3;
         this.score = 0;
+        this.lastKillTime = 0;
+        this.comboMultiplier = 1;
         this.meleeCooldown = 0;
         this.projectileCooldown = 0;
         this.bombCooldown = 0;
@@ -123,5 +125,16 @@ export default class Player {
             this.bombCooldown = 3;
             this.bombs--;
         }
+    }
+
+    addKillScore(baseScore) {
+        const now = performance.now() / 1000;
+        if (now - this.lastKillTime <= 3) {
+            this.comboMultiplier += 1;
+        } else {
+            this.comboMultiplier = 1;
+        }
+        this.lastKillTime = now;
+        this.score += baseScore * this.comboMultiplier;
     }
 }

--- a/js/entities/Projectile.js
+++ b/js/entities/Projectile.js
@@ -48,9 +48,15 @@ export default class Projectile {
                 if (soundManager) soundManager.play('projectileHit');
                 if (enemy.hp <= 0) {
                     if (soundManager) soundManager.play('enemyDeath');
-                    if (enemy.type === 'small') player.score += 10;
-                    else if (enemy.type === 'medium') player.score += 30;
-                    else if (enemy.type === 'large') player.score += 50;
+                    let baseScore = 0;
+                    if (enemy.type === 'small') baseScore = 10;
+                    else if (enemy.type === 'medium') baseScore = 30;
+                    else if (enemy.type === 'large') baseScore = 50;
+                    if (typeof player.addKillScore === 'function') {
+                        player.addKillScore(baseScore);
+                    } else {
+                        player.score += baseScore;
+                    }
                     enemies.splice(i, 1);
                 }
                 return false;

--- a/js/game.js
+++ b/js/game.js
@@ -333,7 +333,8 @@ function updateHUD() {
         Health: ${Math.max(0, Math.floor(player.hp))} <br>
         Acorns: ${player.acorns} <br>
         Bombs: ${player.bombs} <br>
-        Score: ${Math.floor(player.score)}
+        Score: ${Math.floor(player.score)} <br>
+        Combo: x${player.comboMultiplier}
     `;
 }
 
@@ -422,6 +423,8 @@ function respawnPlayer() {
     player.y = canvas.height / 2;
     player.vx = 0;
     player.vy = 0;
+    player.comboMultiplier = 1;
+    player.lastKillTime = 0;
     message.innerText = 'You Died';
     gamePaused = true;
     setTimeout(() => {
@@ -434,6 +437,8 @@ function gameOver() {
     gameRunning = false;
     message.innerText = 'Game Over';
     soundManager.play('gameOver');
+    player.comboMultiplier = 1;
+    player.lastKillTime = 0;
 }
 
 // Splash screen implementation


### PR DESCRIPTION
## Summary
- track last kill time and combo multiplier in Player
- score kills via `addKillScore` so rapid kills get bonus points
- reset combo on player death or game over
- show combo multiplier in the HUD
- keep compatibility with tests by falling back to simple scoring

## Testing
- `node tests/runTests.js`