### PR TITLE
Add failing tests for combo, accuracy and high score

### DIFF
--- a/tests/AccuracyCounters.test.js
+++ b/tests/AccuracyCounters.test.js
@@ -1,0 +1,28 @@
+const assert = require('assert');
+
+(async () => {
+    const { default: Player } = await import('../js/entities/Player.js');
+    const { default: Enemy } = await import('../js/entities/Enemy.js');
+    const { default: Projectile } = await import('../js/entities/Projectile.js');
+
+    const canvas = { width: 100, height: 100 };
+    const player = new Player(0, 0);
+    const projectiles = [];
+    const enemies = [new Enemy(0, 0, 5, 1, 0, 1, 'small', 0, 0)];
+
+    player.shootProjectile(projectiles, null);
+    assert.strictEqual(
+        player.shotsFired,
+        1,
+        'shotsFired counter should increment when a projectile is fired'
+    );
+
+    projectiles[0].update(canvas, enemies, player, null);
+    assert.strictEqual(
+        player.shotsHit,
+        1,
+        'shotsHit counter should increment when a projectile hits'
+    );
+
+    console.log('Accuracy counter tests passed');
+})();

--- a/tests/ComboBonus.test.js
+++ b/tests/ComboBonus.test.js
@@ -1,0 +1,29 @@
+const assert = require('assert');
+
+(async () => {
+    const { default: Player } = await import('../js/entities/Player.js');
+    const { default: Enemy } = await import('../js/entities/Enemy.js');
+    const { default: Projectile } = await import('../js/entities/Projectile.js');
+
+    const canvas = { width: 100, height: 100 };
+    const player = new Player(0, 0);
+    const enemies = [
+        new Enemy(0, 0, 5, 5, 0, 1, 'small', 0, 0),
+        new Enemy(0, 0, 5, 5, 0, 1, 'small', 0, 0)
+    ];
+
+    let p1 = new Projectile(0, 0, 0, 0, 1, 10, 0);
+    p1.update(canvas, enemies, player, null);
+    const scoreAfterFirst = player.score;
+
+    let p2 = new Projectile(0, 0, 0, 0, 1, 10, 0);
+    p2.update(canvas, enemies, player, null);
+    const scoreAfterSecond = player.score;
+
+    assert.ok(
+        scoreAfterSecond > scoreAfterFirst + 10,
+        'Combo bonus should be applied for quick consecutive kills'
+    );
+
+    console.log('Combo bonus tests passed');
+})();

--- a/tests/HighScorePersistence.test.js
+++ b/tests/HighScorePersistence.test.js
@@ -1,0 +1,28 @@
+const assert = require('assert');
+
+(async () => {
+    const { default: Player } = await import('../js/entities/Player.js');
+
+    let gameOver;
+    try {
+        const mod = await import('../js/game.js');
+        gameOver = mod.gameOver || mod.default || mod;
+    } catch (err) {
+        throw err;
+    }
+
+    assert.strictEqual(typeof gameOver, 'function', 'gameOver should be a function');
+
+    const player = new Player(0, 0);
+    player.score = 100;
+    localStorage.clear();
+
+    gameOver(player);
+    assert.strictEqual(localStorage.getItem('highScore'), '100', 'High score should be saved');
+
+    player.score = 50;
+    gameOver(player);
+    assert.strictEqual(localStorage.getItem('highScore'), '100', 'High score should persist when score is lower');
+
+    console.log('High score persistence tests passed');
+})();

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -2,13 +2,40 @@ const fs = require('fs');
 const path = require('path');
 const { pathToFileURL } = require('url');
 
+// Provide a very small localStorage stub for tests running under Node
+if (typeof global.localStorage === 'undefined') {
+    global.localStorage = (() => {
+        let store = {};
+        return {
+            getItem(key) { return Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null; },
+            setItem(key, value) { store[key] = String(value); },
+            removeItem(key) { delete store[key]; },
+            clear() { store = {}; }
+        };
+    })();
+}
+
+let failed = 0;
+process.on('unhandledRejection', err => {
+    failed++;
+    console.error('Unhandled rejection:', err.message);
+});
+
 (async () => {
     const dir = __dirname;
-    const files = fs.readdirSync(dir).filter(f => f.endsWith('.test.js'));
+    const files = fs.readdirSync(dir).filter(f => f.endsWith('.test.js') && f !== 'runTests.js');
     for (const file of files) {
-        if (file === 'runTests.js') continue;
         console.log(`Running ${file}...`);
-        await import(pathToFileURL(path.join(dir, file)).href);
+        try {
+            await import(pathToFileURL(path.join(dir, file)).href);
+        } catch (err) {
+            failed++;
+            console.error(`${file} failed:`, err.message);
+        }
     }
     console.log('All tests completed');
+    if (failed > 0) {
+        console.log(`${failed} test(s) failed`);
+        process.exitCode = 1;
+    }
 })();


### PR DESCRIPTION
## Summary
- add failing tests covering combo bonus, accuracy counters and high score persistence
- update test runner to support localStorage and continue on failures

## Testing
- `node tests/runTests.js` *(fails: shotsFired counter should increment when a projectile is fired, Combo bonus should be applied for quick consecutive kills, Audio is not defined)*