### PR TITLE
Add bomb ring effect

### DIFF
--- a/js/entities/Bomb.js
+++ b/js/entities/Bomb.js
@@ -11,6 +11,11 @@ export default class Bomb {
         this.done = false;
         this.damage = critical ? 100 : 20;
         this.hitEnemies = new Set();
+
+        // Visual effect properties for a fading outer ring during the explosion
+        this.ringRadius = 0;
+        this.ringOpacity = 0;
+        this.ringMaxRadius = this.maxRadius + 30;
     }
 
     update(enemies, player) {
@@ -19,9 +24,13 @@ export default class Bomb {
         if (elapsed < this.durationExpand) {
             this.currentRadius = (elapsed / this.durationExpand) * this.maxRadius;
             this.opacity = 1;
+            this.ringOpacity = 0;
         } else if (elapsed < this.durationExpand + this.durationFade) {
             this.currentRadius = this.maxRadius;
             this.opacity = 1 - ((elapsed - this.durationExpand) / this.durationFade);
+            const progress = (elapsed - this.durationExpand) / this.durationFade;
+            this.ringRadius = this.maxRadius + (this.ringMaxRadius - this.maxRadius) * progress;
+            this.ringOpacity = 1 - progress;
         } else {
             this.done = true;
         }

--- a/js/game.js
+++ b/js/game.js
@@ -357,6 +357,14 @@ function drawBomb(ctx, bomb) {
     ctx.arc(bomb.x, bomb.y, bomb.currentRadius, 0, Math.PI * 2);
     ctx.fillStyle = 'white';
     ctx.fill();
+    if (bomb.ringOpacity > 0) {
+        ctx.globalAlpha = bomb.ringOpacity;
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.arc(bomb.x, bomb.y, bomb.ringRadius, 0, Math.PI * 2);
+        ctx.strokeStyle = 'white';
+        ctx.stroke();
+    }
     ctx.restore();
 }
 


### PR DESCRIPTION
## Summary
- add fading outer ring properties to `Bomb`
- animate ring in `update`
- draw secondary ring in `drawBomb`

## Testing
- `node tests/runTests.js` *(fails: shotsHit counter should increment when a projectile hits; Audio is not defined)*