### PR TITLE
Larger enemy deaths spawn more particles

### DIFF
--- a/js/entities/Bomb.js
+++ b/js/entities/Bomb.js
@@ -1,4 +1,5 @@
 import Particle from './Particle.js';
+import { spawnDeathParticles } from './Enemy.js';
 
 export default class Bomb {
     constructor(x, y, critical = false) {
@@ -57,13 +58,7 @@ export default class Bomb {
                     } else {
                         player.score += baseScore;
                     }
-                    if (particles) {
-                        for (let j = 0; j < 12; j++) {
-                            const a = Math.random() * Math.PI * 2;
-                            const s = Math.random() * 3 + 1;
-                            particles.push(new Particle(enemy.x, enemy.y, Math.cos(a) * s, Math.sin(a) * s, 3, 0.8));
-                        }
-                    }
+                    spawnDeathParticles(enemy, particles);
                     enemies.splice(i, 1);
                 }
             }

--- a/js/entities/Enemy.js
+++ b/js/entities/Enemy.js
@@ -1,3 +1,5 @@
+import Particle from './Particle.js';
+
 export default class Enemy {
     constructor(x, y, size, hp, speed, damage, type, vx, vy) {
         this.x = x;
@@ -23,5 +25,28 @@ export default class Enemy {
             return false;
         }
         return true;
+    }
+}
+
+export function spawnDeathParticles(enemy, particles) {
+    if (!particles) return;
+    let count;
+    switch (enemy.type) {
+        case 'small':
+            count = 8;
+            break;
+        case 'medium':
+            count = 12;
+            break;
+        case 'large':
+            count = 18;
+            break;
+        default:
+            count = 8;
+    }
+    for (let j = 0; j < count; j++) {
+        const a = Math.random() * Math.PI * 2;
+        const s = Math.random() * 3 + 1;
+        particles.push(new Particle(enemy.x, enemy.y, Math.cos(a) * s, Math.sin(a) * s, 2, 0.6));
     }
 }

--- a/js/entities/Melee.js
+++ b/js/entities/Melee.js
@@ -1,5 +1,6 @@
 import { normalizeAngle } from '../utils.js';
 import Particle from './Particle.js';
+import { spawnDeathParticles } from './Enemy.js';
 
 export default class Melee {
     constructor(x, y, angle, range = 50, duration = 0.05) {
@@ -36,13 +37,7 @@ export default class Melee {
                     } else {
                         player.score += baseScore;
                     }
-                    if (particles) {
-                        for (let j = 0; j < 6; j++) {
-                            const a = Math.random() * Math.PI * 2;
-                            const s = Math.random() * 2 + 1;
-                            particles.push(new Particle(enemy.x, enemy.y, Math.cos(a) * s, Math.sin(a) * s, 2, 0.5));
-                        }
-                    }
+                    spawnDeathParticles(enemy, particles);
                     this.alreadyHit.add(enemy);
                     enemies.splice(i, 1);
                 }

--- a/js/entities/Projectile.js
+++ b/js/entities/Projectile.js
@@ -1,4 +1,5 @@
 import Particle from './Particle.js';
+import { spawnDeathParticles } from './Enemy.js';
 
 export default class Projectile {
     constructor(x, y, vx, vy, size, damage, angle) {
@@ -53,13 +54,7 @@ export default class Projectile {
                     } else {
                         player.score += baseScore;
                     }
-                    if (particles) {
-                        for (let j = 0; j < 8; j++) {
-                            const a = Math.random() * Math.PI * 2;
-                            const s = Math.random() * 2 + 1;
-                            particles.push(new Particle(enemy.x, enemy.y, Math.cos(a) * s, Math.sin(a) * s, 2, 0.6));
-                        }
-                    }
+                    spawnDeathParticles(enemy, particles);
                     enemies.splice(i, 1);
                 }
                 return false;

--- a/js/game.js
+++ b/js/game.js
@@ -1,6 +1,6 @@
 import { soundManager } from './sounds.js';
 import Player from "./entities/Player.js";
-import Enemy from "./entities/Enemy.js";
+import Enemy, { spawnDeathParticles } from "./entities/Enemy.js";
 import Projectile from "./entities/Projectile.js";
 import Bomb from "./entities/Bomb.js";
 import Melee from "./entities/Melee.js";
@@ -262,6 +262,7 @@ function checkCollisions() {
 
             // Remove enemy if its health drops to 0 or below
             if (enemy.hp <= 0) {
+                spawnDeathParticles(enemy, particles);
                 enemies.splice(index, 1);
             }
 


### PR DESCRIPTION
## Summary
- make `Enemy.js` export `spawnDeathParticles` helper
- spawn extra particles for larger enemies when killed by projectiles, bombs, melee attacks, or collisions

## Testing
- `node tests/runTests.js`