### PR TITLE
Fix spawn overlap with obstacles

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -14,6 +14,7 @@ import RapidFirePowerUp from "./entities/RapidFirePowerUp.js";
 import SpeedBoostPowerUp from "./entities/SpeedBoostPowerUp.js";
 import Star from "./entities/Star.js";
 import { inputManager } from './InputManager.js';
+import { isClearOfObstacles } from './spawnUtils.js';
 
 
 const canvas = typeof document !== 'undefined' ? document.getElementById('gameCanvas') : { getContext: () => null };
@@ -731,33 +732,53 @@ function spawnEnemies() {
     }
 }
 
+
 function spawnStars() {
     if (Math.random() < 0.01) {
-        const x = Math.random() * canvas.width;
-        const y = Math.random() * canvas.height;
-        stars.push(new Star(x, y));
+        for (let i = 0; i < 10; i++) {
+            const x = Math.random() * canvas.width;
+            const y = Math.random() * canvas.height;
+            if (isClearOfObstacles(x, y, 8, 3)) {
+                stars.push(new Star(x, y));
+                break;
+            }
+        }
     }
 }
 
 function spawnPowerUps() {
     if (Math.random() < 0.003) {
-        const x = Math.random() * canvas.width;
-        const y = Math.random() * canvas.height;
-        const r = Math.random();
-        if (r < 0.33) powerUps.push(new ShieldPowerUp(x, y));
-        else if (r < 0.66) powerUps.push(new RapidFirePowerUp(x, y));
-        else powerUps.push(new SpeedBoostPowerUp(x, y));
+        for (let i = 0; i < 10; i++) {
+            const x = Math.random() * canvas.width;
+            const y = Math.random() * canvas.height;
+            if (isClearOfObstacles(x, y, 8, 3)) {
+                const r = Math.random();
+                if (r < 0.33) powerUps.push(new ShieldPowerUp(x, y));
+                else if (r < 0.66) powerUps.push(new RapidFirePowerUp(x, y));
+                else powerUps.push(new SpeedBoostPowerUp(x, y));
+                break;
+            }
+        }
     }
 }
 
 function spawnObstacles() {
     // Randomly place obstacles
     for (let i = 0; i < 50; i++) {
-        let obstacle = {
-            x: Math.random() * canvas.width,
-            y: Math.random() * canvas.height,
-            size: Math.random() * 20 + 10
-        };
+        let obstacle;
+        let attempts = 0;
+        do {
+            obstacle = {
+                x: Math.random() * canvas.width,
+                y: Math.random() * canvas.height,
+                size: Math.random() * 20 + 10
+            };
+            attempts++;
+        } while (
+            attempts < 20 &&
+            Math.hypot(obstacle.x - canvas.width / 2, obstacle.y - canvas.height / 2) <
+                obstacle.size + player.size + 5
+        );
         obstacles.push(obstacle);
     }
 }

--- a/js/spawnUtils.js
+++ b/js/spawnUtils.js
@@ -1,0 +1,7 @@
+export function isClearOfObstacles(x, y, radius = 0, buffer = 0, obsArr = []) {
+    for (const o of obsArr) {
+        const dist = Math.hypot(x - o.x, y - o.y);
+        if (dist < o.size + radius + buffer) return false;
+    }
+    return true;
+}

--- a/tests/SpawnUtils.test.js
+++ b/tests/SpawnUtils.test.js
@@ -1,0 +1,11 @@
+const assert = require('assert');
+
+(async () => {
+    const { isClearOfObstacles } = await import('../js/spawnUtils.js');
+    const obstacles = [{ x: 0, y: 0, size: 10 }];
+
+    assert.strictEqual(isClearOfObstacles(0, 0, 0, 0, obstacles), false, 'point inside obstacle is not clear');
+    assert.strictEqual(isClearOfObstacles(20, 0, 0, 5, obstacles), true, 'point beyond buffer is clear');
+    assert.strictEqual(isClearOfObstacles(14, 0, 0, 5, obstacles), false, 'point within buffer is not clear');
+    console.log('Spawn utils tests passed');
+})();


### PR DESCRIPTION
## Summary
- prevent stars and power‑ups from spawning inside obstacles
- avoid spawning obstacles where the player appears
- expose spawn utility for tests
- add tests for spawn helper

## Testing
- `node tests/runTests.js`