### PR TITLE
Add enemy death sound to all kill methods

### DIFF
--- a/js/entities/Bomb.js
+++ b/js/entities/Bomb.js
@@ -24,7 +24,7 @@ export default class Bomb {
     }
 
 
-    update(enemies, player, particles, screenShakeCallback = null) {
+    update(enemies, player, particles, screenShakeCallback = null, soundManager = null) {
         const now = performance.now();
         const elapsed = now - this.startTime;
         if (elapsed < this.durationExpand) {
@@ -73,6 +73,7 @@ export default class Bomb {
                     if (enemy instanceof SquareEnemy) {
                         SquareEnemy.split(enemy, enemies);
                     }
+                    if (soundManager) soundManager.play('enemyDeath');
                     spawnDeathParticles(enemy, particles);
                     enemies.splice(i, 1);
                 }

--- a/js/entities/Melee.js
+++ b/js/entities/Melee.js
@@ -16,7 +16,7 @@ export default class Melee {
         this.hasRegisteredHit = false;
     }
 
-    update(enemies, player, particles) {
+    update(enemies, player, particles, soundManager = null) {
         const currentTime = performance.now() / 1000;
         if (currentTime - this.startTime > this.duration) {
             if (!this.hasRegisteredHit && player && typeof player.registerMeleeMiss === 'function') {
@@ -62,6 +62,7 @@ export default class Melee {
                     if (enemy instanceof SquareEnemy) {
                         SquareEnemy.split(enemy, enemies);
                     }
+                    if (soundManager) soundManager.play('enemyDeath');
                     spawnDeathParticles(enemy, particles);
                     this.alreadyHit.add(enemy);
                     enemies.splice(i, 1);

--- a/js/game.js
+++ b/js/game.js
@@ -268,7 +268,7 @@ function updateScenery() {
 
 function updateMelees() {
     for (let i = melees.length - 1; i >= 0; i--) {
-        if (!melees[i].update(enemies, player, particles)) {
+        if (!melees[i].update(enemies, player, particles, soundManager)) {
             melees.splice(i, 1);
         }
     }
@@ -284,7 +284,7 @@ function updateProjectiles() {
 
 function updateBombs() {
     for (let i = bombs.length - 1; i >= 0; i--) {
-        if (!bombs[i].update(enemies, player, particles, () => triggerScreenShake(8, 150))) {
+        if (!bombs[i].update(enemies, player, particles, () => triggerScreenShake(8, 150), soundManager)) {
             bombs.splice(i, 1);
         }
     }
@@ -394,6 +394,7 @@ function checkCollisions() {
                 if (enemy instanceof SquareEnemy) {
                     SquareEnemy.split(enemy, enemies);
                 }
+                soundManager.play('enemyDeath');
                 spawnDeathParticles(enemy, particles);
                 enemies.splice(index, 1);
             }


### PR DESCRIPTION
## Summary
- let melee and bombs play the death sound when an enemy dies
- pass soundManager to melee and bomb updates
- trigger enemy death sound when enemies die from colliding with the player

## Testing
- `node tests/runTests.js`